### PR TITLE
fix: filter out non-user organization in the rank

### DIFF
--- a/src/getUsers.ts
+++ b/src/getUsers.ts
@@ -57,10 +57,12 @@ import { UsersDataBase } from './common/props.js';
       return item
     }, []);
 
-    result = result.map((item: UsersDataBase, idx: number) => {
-      item.rank = idx + 1;
-      return item;
-    });
+    result = result
+      .filter(item => item.type === 'User')
+      .map((item: UsersDataBase, idx: number) => {
+        item.rank = idx + 1;
+        return item;
+      });
 
     FS.outputFileSync(path.join(process.cwd(), '.cache', 'users.json'), JSON.stringify(result, null, 2));
     console.log(`-> 共获取\x1b[32;1m${result.length}\x1b[0m条用户数据！`);

--- a/src/getUsersChina.ts
+++ b/src/getUsersChina.ts
@@ -57,10 +57,12 @@ import { UsersDataBase } from './common/props.js';
       return item
     }, []);
 
-    result = result.map((item: UsersDataBase, idx: number) => {
-      item.rank = idx + 1;
-      return item;
-    });
+    result = result
+      .filter(item => item.type === 'User')
+      .map((item: UsersDataBase, idx: number) => {
+        item.rank = idx + 1;
+        return item;
+      });
 
     FS.outputFileSync(path.join(process.cwd(), '.cache', 'users.china.json'), JSON.stringify(result, null, 2));
     console.log(`-> 共获取\x1b[32;1m${result.length}\x1b[0m条用户数据！`);


### PR DESCRIPTION
Maybe that information can still be useful to have an org ranking. But for now we just filter them out.

I didn't run the crawler but I suppose it would be updated on the next run?